### PR TITLE
Support Python 3.6

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ PROJECT_ROOT=$(dirname $0)
 VIRTUAL_ENV_DIR=$PROJECT_ROOT/venv
 
 if [[ ! -e "$VIRTUAL_ENV_DIR" ]]; then
-    python3.4 -m venv $VIRTUAL_ENV_DIR
+    python3.6 -m venv $VIRTUAL_ENV_DIR
     . $VIRTUAL_ENV_DIR/bin/activate
     pip install -r requirements-dev.txt
 fi

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import os
 import codecs

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     long_description=read('README.rst'),
     install_requires=[
-        'boto3==1.1.2',
+        'boto3==1.4.7',
         'click==5.1',
     ],
     setup_requires=[

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
     ],
     entry_points={
         'console_scripts': 'rds-log-stream=_rds_log.commands.rds_log_stream:main'


### PR DESCRIPTION
Updates boto3 to latest version to support Python3.6

Fixes `TypeError: _send_request() takes 5 positional arguments but 6 were given` caused by boto. See https://github.com/boto/botocore/issues/1079 for more info.